### PR TITLE
Fix deprecated runtime selection `enable-jit` for Frida 12.5 or newer

### DIFF
--- a/badada
+++ b/badada
@@ -297,12 +297,6 @@ class BadadaShell(cmd.Cmd):
             self.hook_lock.release()
             return
 
-        if self.args.enable_jit:
-            if self.args.verbose:
-                print('[*] Enabling JIT...')
-
-            self.session.enable_jit()
-
         if self.args.child_gating:
             self.session.enable_child_gating()
 
@@ -378,12 +372,6 @@ class BadadaShell(cmd.Cmd):
 
             session = self.usb_device.attach(child.pid)
 
-            if self.args.enable_jit:
-                if self.args.verbose:
-                    print('[*] Enabling JIT...')
-
-                session.enable_jit()
-
             session.on('detached', lambda reason: self.on_child_removed(reason, session, child))
 
             if not self.args.avoid_grandchildren_gating:
@@ -398,7 +386,7 @@ class BadadaShell(cmd.Cmd):
             else:
                 hook_source = self.get_file_contents(self.child_gating_hooks[child.identifier])
 
-            self.script = session.create_script(hook_source)
+            self.script = session.create_script(hook_source, runtime='v8' if self.args.enable_jit else 'duk')
             self.script.on('message', self.on_message)
             self.script.load()
 
@@ -472,7 +460,7 @@ class BadadaShell(cmd.Cmd):
 
     def load_script(self, file_name):
         hook_source = self.get_file_contents(file_name)
-        self.script = self.session.create_script(hook_source)
+        self.script = self.session.create_script(hook_source, runtime='v8' if self.args.enable_jit else 'duk')
         self.script.on('message', self.on_message)
         self.script.load()
 
@@ -809,12 +797,6 @@ class BadadaShell(cmd.Cmd):
 
                 try:
                     self.session = self.usb_device.attach(args[0])
-
-                    if self.args.enable_jit:
-                        if self.args.verbose:
-                            print('[*] Enabling JIT...')
-
-                        self.session.enable_jit()
 
                     self.default_rpc_methods = self.load_script(
                         os.path.join(os.path.dirname(os.path.realpath(__file__)), 'scripts/', 'scriptsRPC.js'))


### PR DESCRIPTION
Since Frida 12.5, the `session.enable_jit()` API [was removed](https://frida.re/news/2019/05/15/frida-12-5-released/#runtime-selection), whilst newer versions require you to specify the desired JS runtime during script creation, while also allowing separate scripts to use different runtimes simultaneously.

I patched badada's `--enable-jit` parameter to fix the behavior completely (and thus allow scripts to use v8), however, _"não me dei ao trabalho"_ 😅 to add support for choosing the runtime for each separate script, as that's such a niche case and would increase complexity substantially while bringing barely any real world benefit, that in my opinion it's not really worth it.

Abraços :wave: 